### PR TITLE
공간 상세 페이지 네비게이션 탭 기능

### DIFF
--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -6,24 +6,24 @@ interface DetailNavigatorProps {
 function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
   const [navIndex, setNavIndex] = useState<number>(-1);
   const [navigator, setNavigator] = useState([
-    { index: 0, name: '공간 소개', clicked: false },
-    { index: 1, name: '운영 시간', clicked: false },
-    { index: 2, name: '시설 정보', clicked: false },
-    { index: 3, name: '공간 위치', clicked: false },
+    { index: 0, name: '공간 소개', active: false },
+    { index: 1, name: '운영 시간', active: false },
+    { index: 2, name: '시설 정보', active: false },
+    { index: 3, name: '공간 위치', active: false },
   ]);
   const [scrollY, setScrollY] = useState(0);
 
   const clickNavigator = (index: number) => {
-    let newNavigator = navigator.map((item) => {
+    const newNavigator = navigator.map((item) => {
       if (item.index === index) {
         return {
           ...item,
-          clicked: true,
+          active: true,
         };
       } else {
         return {
           ...item,
-          clicked: false,
+          active: false,
         };
       }
     });
@@ -49,12 +49,12 @@ function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
         ) {
           return {
             ...item,
-            clicked: true,
+            active: true,
           };
         } else {
           return {
             ...item,
-            clicked: false,
+            active: false,
           };
         }
       });
@@ -73,17 +73,15 @@ function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
   return (
     <>
       <nav className="sticky top-0 -ml-4 flex h-[34px] w-screen flex-row items-center justify-between bg-WHTIE px-4">
-        {navigator.map(({ index, name, clicked }) => {
+        {navigator.map(({ index, name, active }) => {
           return (
             <article className=" flex flex-col items-center active:text-BLUE_600">
               <button
                 key={index}
-                onClick={() => {
-                  setNavIndex(index);
-                }}
+                onClick={() => setNavIndex(index)}
                 type="button"
                 className={`flex flex-col items-center font-system4_bold text-system4_bold ${
-                  clicked ? 'text-BLUE_600' : 'text-GRAY_300 '
+                  active ? 'text-BLUE_600' : 'text-GRAY_300 '
                 }`}
               >
                 <p className="flex h-[36px] flex-row items-center active:text-BLUE_600">
@@ -91,7 +89,7 @@ function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
                 </p>
                 <p
                   className={` h-[3px] w-[84px]  rounded-full ${
-                    clicked ? 'bg-BLUE_600 ' : null
+                    active && 'bg-BLUE_600 '
                   }`}
                 ></p>
               </button>

--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -35,7 +35,7 @@ function DetailNavigator() {
   }, [navIndex]);
 
   useEffect(() => {
-    const handleShadow = () => {
+    const handleScroll = () => {
       setScrollY(document.body.scrollTop);
 
       const newNavigator = navigator.map((item) => {
@@ -57,14 +57,13 @@ function DetailNavigator() {
             active: false,
           };
         }
-        // }
       });
 
       setNavigator(newNavigator);
     };
 
-    window.addEventListener('scroll', handleShadow, true);
-    return window.removeEventListener('scroll', handleShadow);
+    window.addEventListener('scroll', handleScroll, true);
+    return window.removeEventListener('scroll', handleScroll);
   }, [scrollY]);
 
   useEffect(() => {

--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -1,9 +1,6 @@
-import React, { useState, useEffect, MutableRefObject } from 'react';
-interface DetailNavigatorProps {
-  scrollRef: MutableRefObject<HTMLDivElement[]>;
-}
+import React, { useState, useEffect } from 'react';
 
-function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
+function DetailNavigator() {
   const [navIndex, setNavIndex] = useState<number>(-1);
   const [navigator, setNavigator] = useState([
     { index: 0, name: '공간 소개', active: false },
@@ -32,20 +29,23 @@ function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
   };
 
   useEffect(() => {
-    scrollRef.current[navIndex]?.scrollIntoView({ behavior: 'smooth' });
+    const activeTab = document.getElementById(`nav-${navIndex}`);
+    activeTab?.scrollIntoView({ behavior: 'smooth' });
     clickNavigator(navIndex);
-  }, [scrollRef, navIndex]);
+  }, [navIndex]);
 
   useEffect(() => {
     const handleShadow = () => {
       setScrollY(document.body.scrollTop);
 
-      let newNavigator = navigator.map((item) => {
+      const newNavigator = navigator.map((item) => {
+        const activeTab = document.getElementById(`nav-${item.index}`);
+        const nextTab = document.getElementById(`nav-${item.index + 1}`);
         if (
-          scrollRef.current[item.index].offsetTop - 70 <
-            document.body.scrollTop &&
-          document.body.scrollTop <
-            scrollRef.current[item.index + 1].offsetTop - 70
+          activeTab &&
+          nextTab &&
+          activeTab?.offsetTop - 70 < document.body.scrollTop &&
+          document.body.scrollTop < nextTab?.offsetTop - 70
         ) {
           return {
             ...item,
@@ -57,6 +57,7 @@ function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
             active: false,
           };
         }
+        // }
       });
 
       setNavigator(newNavigator);

--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -1,26 +1,106 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, MutableRefObject } from 'react';
+interface DetailNavigatorProps {
+  scrollRef: MutableRefObject<HTMLDivElement[]>;
+}
 
-const DETAIL_NAVIGATOR = [
-  { index: 0, name: '공간 소개' },
-  { index: 1, name: '운영 시간' },
-  { index: 2, name: '시설 정보' },
-  { index: 3, name: '공간 위치' },
-];
+function DetailNavigator({ scrollRef }: DetailNavigatorProps) {
+  const [navIndex, setNavIndex] = useState<number>(-1);
+  const [navigator, setNavigator] = useState([
+    { index: 0, name: '공간 소개', clicked: false },
+    { index: 1, name: '운영 시간', clicked: false },
+    { index: 2, name: '시설 정보', clicked: false },
+    { index: 3, name: '공간 위치', clicked: false },
+  ]);
+  const [scrollY, setScrollY] = useState(0);
 
-function DetailNavigator({ scrollRef }) {
+  const clickNavigator = (index: number) => {
+    let newNavigator = navigator.map((item) => {
+      if (item.index === index) {
+        return {
+          ...item,
+          clicked: true,
+        };
+      } else {
+        return {
+          ...item,
+          clicked: false,
+        };
+      }
+    });
+
+    setNavigator(newNavigator);
+  };
+
+  useEffect(() => {
+    scrollRef.current[navIndex]?.scrollIntoView({ behavior: 'smooth' });
+    clickNavigator(navIndex);
+  }, [scrollRef, navIndex]);
+
+  useEffect(() => {
+    const handleShadow = () => {
+      setScrollY(document.body.scrollTop);
+
+      let newNavigator = navigator.map((item) => {
+        if (
+          scrollRef.current[item.index].offsetTop - 70 <
+            document.body.scrollTop &&
+          document.body.scrollTop <
+            scrollRef.current[item.index + 1].offsetTop - 70
+        ) {
+          return {
+            ...item,
+            clicked: true,
+          };
+        } else {
+          return {
+            ...item,
+            clicked: false,
+          };
+        }
+      });
+
+      setNavigator(newNavigator);
+    };
+
+    window.addEventListener('scroll', handleShadow, true);
+    return window.removeEventListener('scroll', handleShadow);
+  }, [scrollY]);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
-    <nav className="flex flex-row items-center justify-between">
-      {DETAIL_NAVIGATOR.map(({ index, name }) => (
-        <button
-          key={index}
-          type="button"
-          className="font-system4_bold text-system4_bold text-GRAY_300 active:text-BLUE_600 "
-        >
-          {name}
-        </button>
-      ))}
-      <div className="w-3 text-GRAY_300 active:text-BLUE_600 "></div>
-    </nav>
+    <>
+      <nav className="sticky top-0 -ml-4 flex h-[34px] w-screen flex-row items-center justify-between bg-WHTIE px-4">
+        {navigator.map(({ index, name, clicked }) => {
+          return (
+            <article className=" flex flex-col items-center active:text-BLUE_600">
+              <button
+                key={index}
+                onClick={() => {
+                  setNavIndex(index);
+                }}
+                type="button"
+                className={`flex flex-col items-center font-system4_bold text-system4_bold ${
+                  clicked ? 'text-BLUE_600' : 'text-GRAY_300 '
+                }`}
+              >
+                <p className="flex h-[36px] flex-row items-center active:text-BLUE_600">
+                  {name}
+                </p>
+                <p
+                  className={` h-[3px] w-[84px]  rounded-full ${
+                    clicked ? 'bg-BLUE_600 ' : null
+                  }`}
+                ></p>
+              </button>
+            </article>
+          );
+        })}
+      </nav>
+      <div className="-ml-4 mb-6  h-[2px] w-screen bg-GRAY_100"></div>
+    </>
   );
 }
 

--- a/src/components/detail/PlaceDetailInfo.tsx
+++ b/src/components/detail/PlaceDetailInfo.tsx
@@ -6,15 +6,15 @@ import PlaceIntroduce from './placeDetailNav/PlaceIntroduce';
 import PlaceLocation from './placeDetailNav/PlaceLocation';
 
 function PlaceDetailInfo() {
-  const scrollRef = useRef([]);
+  const scrollRef = useRef<HTMLDivElement[]>([]);
 
   return (
     <main>
       <DetailNavigator scrollRef={scrollRef} />
-      <PlaceIntroduce />
-      <OperatingTime />
-      <FacilityInformation />
-      <PlaceLocation />
+      <PlaceIntroduce ref={scrollRef} />
+      <OperatingTime ref={scrollRef} />
+      <FacilityInformation ref={scrollRef} />
+      <PlaceLocation ref={scrollRef} />
     </main>
   );
 }

--- a/src/components/detail/PlaceDetailInfo.tsx
+++ b/src/components/detail/PlaceDetailInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import DetailNavigator from './DetailNavigator';
 import FacilityInformation from './placeDetailNav/FacilityInformation';
 import OperatingTime from './placeDetailNav/OperatingTime';
@@ -6,15 +6,13 @@ import PlaceIntroduce from './placeDetailNav/PlaceIntroduce';
 import PlaceLocation from './placeDetailNav/PlaceLocation';
 
 function PlaceDetailInfo() {
-  const scrollRef = useRef<HTMLDivElement[]>([]);
-
   return (
     <main>
-      <DetailNavigator scrollRef={scrollRef} />
-      <PlaceIntroduce ref={scrollRef} />
-      <OperatingTime ref={scrollRef} />
-      <FacilityInformation ref={scrollRef} />
-      <PlaceLocation ref={scrollRef} />
+      <DetailNavigator />
+      <PlaceIntroduce />
+      <OperatingTime />
+      <FacilityInformation />
+      <PlaceLocation />
     </main>
   );
 }

--- a/src/components/detail/placeDetailNav/FacilityInformation.tsx
+++ b/src/components/detail/placeDetailNav/FacilityInformation.tsx
@@ -1,3 +1,4 @@
+import React, { forwardRef } from "react";
 import facilityInformation from '@/assets/icons/facilityInformation.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 import DetailInformationTextBox from '@/components/common/detail/DetailInformationTextBox';
@@ -18,9 +19,9 @@ const FACILITY_LIST = [
   { icon: person, title: '최대 수용 인원', status: '최대 10명' },
 ];
 
-function FacilityInformation() {
+const FacilityInformation = forwardRef((props, ref) => {
   return (
-    <section className="mb-9">
+    <section className="mb-9 scroll-mt-[50px]"  ref={reviewRef => (ref.current[2] = reviewRef)}>
       <DetailInformationTitle icon={facilityInformation} title="시설 정보" />
       <DetailInformationTextBox>
         <div className="mb-1.5 flex flex-col items-start">
@@ -83,6 +84,6 @@ function FacilityInformation() {
       </DetailInformationTextBox>
     </section>
   );
-}
+});
 
 export default FacilityInformation;

--- a/src/components/detail/placeDetailNav/FacilityInformation.tsx
+++ b/src/components/detail/placeDetailNav/FacilityInformation.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React from 'react';
 import facilityInformation from '@/assets/icons/facilityInformation.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 import DetailInformationTextBox from '@/components/common/detail/DetailInformationTextBox';
@@ -19,9 +19,9 @@ const FACILITY_LIST = [
   { icon: person, title: '최대 수용 인원', status: '최대 10명' },
 ];
 
-const FacilityInformation = forwardRef((props, ref) => {
+function FacilityInformation() {
   return (
-    <section className="mb-9 scroll-mt-[50px]"  ref={reviewRef => (ref.current[2] = reviewRef)}>
+    <section id="nav-2" className="mb-9 scroll-mt-[50px]">
       <DetailInformationTitle icon={facilityInformation} title="시설 정보" />
       <DetailInformationTextBox>
         <div className="mb-1.5 flex flex-col items-start">
@@ -84,6 +84,6 @@ const FacilityInformation = forwardRef((props, ref) => {
       </DetailInformationTextBox>
     </section>
   );
-});
+}
 
 export default FacilityInformation;

--- a/src/components/detail/placeDetailNav/OperatingTime.tsx
+++ b/src/components/detail/placeDetailNav/OperatingTime.tsx
@@ -1,14 +1,11 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import operatingTime from '@/assets/icons/operatingTime.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 import DetailInformationTextBox from '@/components/common/detail/DetailInformationTextBox';
 
-const OperatingTime = forwardRef((props, ref) => {
+function OperatingTime() {
   return (
-    <section
-      className="mb-9 scroll-mt-[50px]"
-      ref={(reviewRef) => (ref.current[1] = reviewRef)}
-    >
+    <section id="nav-1" className="mb-9 scroll-mt-[50px]">
       <DetailInformationTitle icon={operatingTime} title="운영 시간" />
       <DetailInformationTextBox>
         <div className="mb-1.5 flex flex-row items-start">
@@ -33,6 +30,6 @@ const OperatingTime = forwardRef((props, ref) => {
       </DetailInformationTextBox>
     </section>
   );
-});
+}
 
 export default OperatingTime;

--- a/src/components/detail/placeDetailNav/OperatingTime.tsx
+++ b/src/components/detail/placeDetailNav/OperatingTime.tsx
@@ -1,10 +1,14 @@
+import React, { forwardRef } from 'react';
 import operatingTime from '@/assets/icons/operatingTime.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 import DetailInformationTextBox from '@/components/common/detail/DetailInformationTextBox';
 
-function OperatingTime() {
+const OperatingTime = forwardRef((props, ref) => {
   return (
-    <section className="mb-9">
+    <section
+      className="mb-9 scroll-mt-[50px]"
+      ref={(reviewRef) => (ref.current[1] = reviewRef)}
+    >
       <DetailInformationTitle icon={operatingTime} title="운영 시간" />
       <DetailInformationTextBox>
         <div className="mb-1.5 flex flex-row items-start">
@@ -29,6 +33,6 @@ function OperatingTime() {
       </DetailInformationTextBox>
     </section>
   );
-}
+});
 
 export default OperatingTime;

--- a/src/components/detail/placeDetailNav/PlaceIntroduce.tsx
+++ b/src/components/detail/placeDetailNav/PlaceIntroduce.tsx
@@ -1,10 +1,10 @@
-import React, { forwardRef } from "react";
+import React from 'react';
 import placeIntroduce from '@/assets/icons/placeIntroduce.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 
-const PlaceIntroduce = forwardRef((props, ref) => {
+function PlaceIntroduce() {
   return (
-    <section className="mb-9 scroll-mt-[50px]" ref={reviewRef => (ref.current[0] = reviewRef)}>
+    <section id="nav-0" className="mb-9 scroll-mt-[50px]">
       <DetailInformationTitle icon={placeIntroduce} title="공간 소개" />
       <p className="font-system4 text-system4 text-GRAY_600">
         지방자치단체는 주민의 복리에 관한 사무를 처리하고 재산을 관리하며,
@@ -14,6 +14,6 @@ const PlaceIntroduce = forwardRef((props, ref) => {
       </p>
     </section>
   );
-});
+}
 
 export default PlaceIntroduce;

--- a/src/components/detail/placeDetailNav/PlaceIntroduce.tsx
+++ b/src/components/detail/placeDetailNav/PlaceIntroduce.tsx
@@ -1,11 +1,11 @@
+import React, { forwardRef } from "react";
 import placeIntroduce from '@/assets/icons/placeIntroduce.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 
-function PlaceIntroduce() {
+const PlaceIntroduce = forwardRef((props, ref) => {
   return (
-    <section className="mb-9">
+    <section className="mb-9 scroll-mt-[50px]" ref={reviewRef => (ref.current[0] = reviewRef)}>
       <DetailInformationTitle icon={placeIntroduce} title="공간 소개" />
-
       <p className="font-system4 text-system4 text-GRAY_600">
         지방자치단체는 주민의 복리에 관한 사무를 처리하고 재산을 관리하며,
         법령의 범위안에서 자치에 관한 규정을 제정할 수 있다. 모든 국민은
@@ -14,6 +14,6 @@ function PlaceIntroduce() {
       </p>
     </section>
   );
-}
+});
 
 export default PlaceIntroduce;

--- a/src/components/detail/placeDetailNav/PlaceLocation.tsx
+++ b/src/components/detail/placeDetailNav/PlaceLocation.tsx
@@ -1,13 +1,10 @@
-import React, { Ref, forwardRef } from 'react';
+import React from 'react';
 import placeLocation from '@/assets/icons/placeLocation.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 
-const PlaceLocation = forwardRef((props, ref) => {
+function PlaceLocation() {
   return (
-    <section
-      className="mb-9 scroll-mt-[50px]"
-      ref={(reviewRef) => (ref.current[3] = reviewRef)}
-    >
+    <section id="nav-3" className="mb-9 scroll-mt-[50px]">
       <DetailInformationTitle icon={placeLocation} title="공간 위치" />
       <div className="mb-24 h-[300px] bg-BLUE_100">
         지도가 들어갈 부분입니다.
@@ -15,6 +12,6 @@ const PlaceLocation = forwardRef((props, ref) => {
       <div>아이폰 바</div>
     </section>
   );
-});
+}
 
 export default PlaceLocation;

--- a/src/components/detail/placeDetailNav/PlaceLocation.tsx
+++ b/src/components/detail/placeDetailNav/PlaceLocation.tsx
@@ -1,13 +1,20 @@
+import React, { Ref, forwardRef } from 'react';
 import placeLocation from '@/assets/icons/placeLocation.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
-import Image from 'next/image';
 
-function PlaceLocation() {
+const PlaceLocation = forwardRef((props, ref) => {
   return (
-    <section className="mb-9">
+    <section
+      className="mb-9 scroll-mt-[50px]"
+      ref={(reviewRef) => (ref.current[3] = reviewRef)}
+    >
       <DetailInformationTitle icon={placeLocation} title="공간 위치" />
+      <div className="mb-24 h-[300px] bg-BLUE_100">
+        지도가 들어갈 부분입니다.
+      </div>
+      <div>아이폰 바</div>
     </section>
   );
-}
+});
 
 export default PlaceLocation;

--- a/src/pages/detail/[id].tsx
+++ b/src/pages/detail/[id].tsx
@@ -10,13 +10,11 @@ function Detail() {
     imgUrls: ['111', '222', '333'],
   };
   return (
-    <div className="h-screen ">
-      <Layout right={login}>
-        <ImageCarousel imgUrls={dummyData.imgUrls} />
-        <PlaceInfo tags={dummyData.tags} />
-        <PlaceDetailInfo />
-      </Layout>
-    </div>
+    <Layout right={login}>
+      <ImageCarousel imgUrls={dummyData.imgUrls} />
+      <PlaceInfo tags={dummyData.tags} />
+      <PlaceDetailInfo />
+    </Layout>
   );
 }
 

--- a/src/pages/detail/[id].tsx
+++ b/src/pages/detail/[id].tsx
@@ -1,6 +1,6 @@
 import Layout from '@/components/common/Layout';
 import login from '@/assets/icons/login.svg';
-import PlaceInfo from '@/components/detail/PlaceInfo';
+import PlaceInfo from '@/components/detail/PlaceInfo.tsx';
 import ImageCarousel from '@/components/detail/ImageCarousel';
 import PlaceDetailInfo from '@/components/detail/PlaceDetailInfo';
 
@@ -10,11 +10,13 @@ function Detail() {
     imgUrls: ['111', '222', '333'],
   };
   return (
-    <Layout right={login}>
-      <ImageCarousel imgUrls={dummyData.imgUrls} />
-      <PlaceInfo tags={dummyData.tags} />
-      <PlaceDetailInfo />
-    </Layout>
+    <div className="h-screen ">
+      <Layout right={login}>
+        <ImageCarousel imgUrls={dummyData.imgUrls} />
+        <PlaceInfo tags={dummyData.tags} />
+        <PlaceDetailInfo />
+      </Layout>
+    </div>
   );
 }
 


### PR DESCRIPTION
### 관련 이슈
- close #14 

### 구현 사항
공간 상세 페이지 네비게이션 탭 기능
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/62867581/236990839-5156d459-7fc1-41c5-9e1d-0705bfcf5759.gif)

- [x]  NavBar 버튼을 클릭하면 페이지 내에서 해당 DOM 위치로 스크롤 이동
- [x] 현재 스크롤 위치의 DOM에 해당하는 NavBar 버튼 스타일 강조하는 것
-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

현재는 스크롤이 컴포넌트의 높이 +-70안으로 들어오게 되면 자동으로 탭 컬러가 바뀌도록 지정되어 있습니다.
공간 위치 컴포넌트가 제일 아래에 위치하여 컴포넌트 높이에는 절대 스크롤이 들어오지 않아 , 공간 위치 컴포넌트로 포커싱이 맞춰지지 않는 문제가 발생합니다... ( 시설 정보에 계속 포커싱이 갑니다. )
밥법은 공간 위치 컴포넌트 아래 여백을 두어서 화면 상단으로 끌여 올려야할 것 같긴한데 어떻게 할지 고민이네요
![IMG_7541](https://user-images.githubusercontent.com/62867581/236989557-906fc7bc-0db4-49e2-9e51-4834587b24b1.PNG)

------------
### Reference

🔽 forwarding 
https://legacy.reactjs.org/docs/forwarding-refs.html


 🔽 해당 글을 참고하여 기능을 구현했습니다.
https://velog.io/@seoltang/scroll-navbar-button-useref

-------------

