### PR TITLE
[Feat] 마커 이벤트

### DIFF
--- a/src/components/detail/location/Map.tsx
+++ b/src/components/detail/location/Map.tsx
@@ -14,10 +14,11 @@ interface PlacePosition {
 }
 
 interface MapProps {
+  place: string;
   location: string;
 }
 
-function Map({ location }: MapProps) {
+function Map({ place, location }: MapProps) {
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [cmap, setMap]: any = useState();
 
@@ -61,7 +62,7 @@ function Map({ location }: MapProps) {
             setMap(map);
 
             // 공간 정보 마커 표시
-            const imageSize = new window.kakao.maps.Size(60, 60);
+            const imageSize = new window.kakao.maps.Size(130, 130);
 
             const markerImage = new window.kakao.maps.MarkerImage(
               'https://wokat-default-image.s3.ap-northeast-2.amazonaws.com/default-mapMarker.svg',
@@ -73,6 +74,41 @@ function Map({ location }: MapProps) {
               map: map,
               position: coords,
               image: markerImage,
+            });
+
+            // HTML 문자열 또는 Dom Element의 커스텀 오버레이에 표시할 내용입니다
+            const customOverlayContent = `
+            <articel  style="color : #576981;text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard'; font-style: normal;
+            font-weight: 600;
+            font-size: 13px;
+            line-height: 16px;
+            text-align: center;"
+            >${place}</articel>`;
+            const customOverlay = new window.kakao.maps.CustomOverlay({
+              position: coords,
+              content: customOverlayContent,
+            });
+
+            customOverlay.setMap(map);
+
+            // 마커 클릭시
+            window.kakao.maps.event.addListener(marker, 'click', function () {
+              customOverlay.setMap(null);
+              const newOverlayContent = `
+              <articel style="color:#0066FF; text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard';
+              font-style: normal;
+              font-weight: 700;
+              font-size: 14px;
+              line-height: 150%;
+              text-align: center;
+              letter-spacing: -0.02em;">${place}</articel>`;
+
+              const newOverlay = new window.kakao.maps.CustomOverlay({
+                position: coords,
+                content: newOverlayContent,
+              });
+
+              newOverlay.setMap(map);
             });
           }
         },
@@ -100,7 +136,7 @@ function Map({ location }: MapProps) {
     <div className="relative -ml-4 -mr-4 h-[90vh] w-screen overflow-hidden ">
       <article
         id="map"
-        className="relative z-0 w-full h-full overflow-hidden "
+        className="relative z-0 h-full w-full overflow-hidden "
       ></article>
       <button
         type="button"

--- a/src/components/detail/location/Map.tsx
+++ b/src/components/detail/location/Map.tsx
@@ -70,7 +70,7 @@ function Map({ place, location }: MapProps) {
             );
 
             // 결과값으로 받은 위치를 마커로 표시합니다
-            const marker = new window.kakao.maps.Marker({
+            new window.kakao.maps.Marker({
               map: map,
               position: coords,
               image: markerImage,
@@ -78,38 +78,19 @@ function Map({ place, location }: MapProps) {
 
             // HTML 문자열 또는 Dom Element의 커스텀 오버레이에 표시할 내용입니다
             const customOverlayContent = `
-            <article  style="color : #576981;text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard'; font-style: normal;
-            font-weight: 600;
-            font-size: 13px;
-            line-height: 16px;
-            text-align: center;"
-            >${place}</article>`;
+            <article style="color:#0066FF; text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard';
+            font-style: normal;
+            font-weight: 700;
+            font-size: 14px;
+            line-height: 150%;
+            text-align: center;
+            letter-spacing: -0.02em;">${place}</article>`;
             const customOverlay = new window.kakao.maps.CustomOverlay({
               position: coords,
               content: customOverlayContent,
             });
 
             customOverlay.setMap(map);
-
-            // 마커 클릭시
-            window.kakao.maps.event.addListener(marker, 'click', function () {
-              customOverlay.setMap(null);
-              const newOverlayContent = `
-              <article style="color:#0066FF; text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard';
-              font-style: normal;
-              font-weight: 700;
-              font-size: 14px;
-              line-height: 150%;
-              text-align: center;
-              letter-spacing: -0.02em;">${place}</article>`;
-
-              const newOverlay = new window.kakao.maps.CustomOverlay({
-                position: coords,
-                content: newOverlayContent,
-              });
-
-              newOverlay.setMap(map);
-            });
           }
         },
       );

--- a/src/components/detail/location/Map.tsx
+++ b/src/components/detail/location/Map.tsx
@@ -78,12 +78,12 @@ function Map({ place, location }: MapProps) {
 
             // HTML 문자열 또는 Dom Element의 커스텀 오버레이에 표시할 내용입니다
             const customOverlayContent = `
-            <articel  style="color : #576981;text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard'; font-style: normal;
+            <article  style="color : #576981;text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard'; font-style: normal;
             font-weight: 600;
             font-size: 13px;
             line-height: 16px;
             text-align: center;"
-            >${place}</articel>`;
+            >${place}</article>`;
             const customOverlay = new window.kakao.maps.CustomOverlay({
               position: coords,
               content: customOverlayContent,
@@ -95,13 +95,13 @@ function Map({ place, location }: MapProps) {
             window.kakao.maps.event.addListener(marker, 'click', function () {
               customOverlay.setMap(null);
               const newOverlayContent = `
-              <articel style="color:#0066FF; text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard';
+              <article style="color:#0066FF; text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white; font-family: 'Pretendard';
               font-style: normal;
               font-weight: 700;
               font-size: 14px;
               line-height: 150%;
               text-align: center;
-              letter-spacing: -0.02em;">${place}</articel>`;
+              letter-spacing: -0.02em;">${place}</article>`;
 
               const newOverlay = new window.kakao.maps.CustomOverlay({
                 position: coords,

--- a/src/components/detail/placeDetailNav/PlaceLocation.tsx
+++ b/src/components/detail/placeDetailNav/PlaceLocation.tsx
@@ -28,7 +28,7 @@ function PlaceLocation({ place, location }: PlaceLocationProps) {
           href={{
             pathname: `/detail/${router.query.id}/location`,
             query: {
-              title: place,
+              place: place,
               location: location,
             },
           }}

--- a/src/pages/detail/[id]/location.tsx
+++ b/src/pages/detail/[id]/location.tsx
@@ -4,19 +4,21 @@ import { useRouter } from 'next/router';
 
 interface ctxType {
   query: {
+    place: string;
     location: string;
   };
 }
 
 interface Props {
+  place: string;
   location: string;
 }
 
-function Location({ location }: Props) {
+function Location({ place, location }: Props) {
   const router = useRouter();
   return (
     <Layout>
-      <Map location={location} />
+      <Map place={place} location={location} />
       <article className="fixed bottom-0 z-10 -ml-4 h-[198px] w-full rounded-t-[20px] bg-WHTIE p-[16px] shadow-[0_-6px_34px_rgb(0,0,0,0.15)]">
         <h1 className="mt-[14px] font-system3_bold text-system3_bold text-GRAY_800">
           {router.query.title}
@@ -51,6 +53,6 @@ export default Location;
 
 export const getServerSideProps = async (context: ctxType) => {
   const { query } = context;
-  const { location } = query;
-  return { props: { location } };
+  const { place, location } = query;
+  return { props: { place, location } };
 };


### PR DESCRIPTION
### 관련 이슈
- close #35 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->
- [x] 마커 타이틀 표시

[클릭 전, 기본]
<img width="159" alt="image" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/e0483c5d-aff8-4795-99f1-38bf8185998e">
[클릭 후, 타이틀 크기 커지고 색상 변동]
<img width="123" alt="image" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/83ceaf9e-f685-4d44-916f-d78b8fc014e5">
-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->

마커 이벤트 작업 결과 입니다!
카카오 API 중 customoverlay를 이용했어요.
마커가 하나일때 기준으로 작업을 했는데 림이 파트에서 여러개의 마커가 뜨는 것 같아 이부분은 추가로 구현이 필요할 것 같아요!

해당 공간 위치 정보에 관한 지도 뷰인데, 이 뷰에 마커가 여러개뜨는 부분들 작동이 어떻게 되는지 이해가 안돼서,,, 일단은 하나일때 기준으로 작업을 했고 추후에 더 작업을 해야할 것 같습니다! 

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->
https://apis.map.kakao.com/web/sample/customOverlay1/

-------------

