### PR TITLE
공간 상세 뷰 리팩토링

### DIFF
--- a/src/components/detail/PlaceDetailInfo.tsx
+++ b/src/components/detail/PlaceDetailInfo.tsx
@@ -11,7 +11,7 @@ import { Information } from '@/types/information';
 interface PlaceDetailInfoProps {
   place: string;
   category: string;
-  introduce: string;
+  introduce: string[];
   information: Information;
   operationHours: OperationHours;
   maxPeopleCount: string;

--- a/src/components/detail/imageCarousel.tsx
+++ b/src/components/detail/imageCarousel.tsx
@@ -16,10 +16,11 @@ function ImageCarousel({ imageURLs }: ImageCarouselProps) {
     slidesToScroll: 1,
     initialSlide: 0,
     arrows: false,
+    className: 'detail-slider',
   };
 
   return (
-    <Slider className="-ml-4 w-screen" {...settings}>
+    <Slider {...settings}>
       {imageURLs?.map((imageURL, index) => {
         return (
           <section key={index}>

--- a/src/components/detail/imageCarousel.tsx
+++ b/src/components/detail/imageCarousel.tsx
@@ -28,8 +28,10 @@ function ImageCarousel({ imageURLs }: ImageCarouselProps) {
               <Image
                 src={imageURL}
                 alt="place image"
-                width={481}
-                height={192}
+                width={0}
+                height={0}
+                sizes="100vw"
+                style={{ width: '100%', height: 'auto' }}
               />
             </p>
           </section>

--- a/src/components/detail/location/Map.tsx
+++ b/src/components/detail/location/Map.tsx
@@ -29,9 +29,21 @@ function Map({ place, location }: MapProps) {
     const mapScript = document.createElement('script');
     mapScript.async = true;
     mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAOMAP_KEY}&autoload=false&libraries=services`;
+
+    const handleScriptLoad = () => {
+      setMapLoaded(true);
+    };
+
+    if (location) {
+      mapScript.addEventListener('load', handleScriptLoad);
+    }
     document.head.appendChild(mapScript);
-    mapScript.addEventListener('load', () => setMapLoaded(true));
-  }, []);
+
+    return () => {
+      if (location) mapScript.removeEventListener('load', handleScriptLoad);
+      document.head.removeChild(mapScript);
+    };
+  }, [location]);
 
   //지도 로드 및 마커 표시
   useEffect(() => {
@@ -134,7 +146,7 @@ function Map({ place, location }: MapProps) {
     <div className="relative -ml-4 -mr-4 h-[90vh] w-screen overflow-hidden ">
       <article
         id="map"
-        className="relative z-0 w-full h-full overflow-hidden "
+        className="relative z-0 h-full w-full overflow-hidden "
       ></article>
       <button
         type="button"

--- a/src/components/detail/placeDetailNav/FacilityInformation.tsx
+++ b/src/components/detail/placeDetailNav/FacilityInformation.tsx
@@ -104,7 +104,7 @@ function FacilityInformation({
                 </h2>
               </div>
               <p className="flex w-32 flex-row justify-end text-system4 font-system4 text-GRAY_400">
-                {item.status}
+                {item.status === null ? '-' : item.status}
               </p>
             </div>
           );

--- a/src/components/detail/placeDetailNav/Map.tsx
+++ b/src/components/detail/placeDetailNav/Map.tsx
@@ -23,8 +23,20 @@ function Map({ location }: MapProps) {
     const mapScript = document.createElement('script');
     mapScript.async = true;
     mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAOMAP_KEY}&autoload=false&libraries=services`;
+
+    const handleScriptLoad = () => {
+      setMapLoaded(true);
+    };
+
+    if (location) {
+      mapScript.addEventListener('load', handleScriptLoad);
+    }
     document.head.appendChild(mapScript);
-    if (location) mapScript.addEventListener('load', () => setMapLoaded(true));
+
+    return () => {
+      if (location) mapScript.removeEventListener('load', handleScriptLoad);
+      document.head.removeChild(mapScript);
+    };
   }, [location]);
 
   //지도 로드 및 마커 표시

--- a/src/components/detail/placeDetailNav/Map.tsx
+++ b/src/components/detail/placeDetailNav/Map.tsx
@@ -24,8 +24,8 @@ function Map({ location }: MapProps) {
     mapScript.async = true;
     mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAOMAP_KEY}&autoload=false&libraries=services`;
     document.head.appendChild(mapScript);
-    mapScript.addEventListener('load', () => setMapLoaded(true));
-  }, []);
+    if (location) mapScript.addEventListener('load', () => setMapLoaded(true));
+  }, [location]);
 
   //지도 로드 및 마커 표시
   useEffect(() => {
@@ -80,7 +80,7 @@ function Map({ location }: MapProps) {
     <div className="relative h-[216px]  overflow-hidden rounded-t-[10px] ">
       <article
         id="map"
-        className="relative z-0 w-full h-full overflow-hidden "
+        className="relative z-0 h-full w-full overflow-hidden "
       ></article>
     </div>
   );

--- a/src/components/detail/placeDetailNav/Map.tsx
+++ b/src/components/detail/placeDetailNav/Map.tsx
@@ -12,10 +12,11 @@ interface PlacePosition {
 }
 
 interface MapProps {
+  addressHeight: number;
   location: string;
 }
 
-function Map({ location }: MapProps) {
+function Map({ addressHeight, location }: MapProps) {
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
 
   //지도 로드하기
@@ -89,7 +90,12 @@ function Map({ location }: MapProps) {
   }, [mapLoaded]);
 
   return (
-    <div className="relative h-[216px]  overflow-hidden rounded-t-[10px] ">
+    <div
+      style={{
+        height: `calc(237px - ${addressHeight}px)`,
+      }}
+      className="relative h-[216px] overflow-hidden rounded-t-[10px] "
+    >
       <article
         id="map"
         className="relative z-0 h-full w-full overflow-hidden "

--- a/src/components/detail/placeDetailNav/PlaceIntroduce.tsx
+++ b/src/components/detail/placeDetailNav/PlaceIntroduce.tsx
@@ -3,15 +3,24 @@ import placeIntroduce from '@/assets/icons/placeIntroduce.svg';
 import DetailInformationTitle from '@/components/common/detail/DetailInformationTitle';
 
 interface PlaceIntroduceProps {
-  introduce: string;
+  introduce: string[];
 }
 function PlaceIntroduce({ introduce }: PlaceIntroduceProps) {
   return (
     <section id="nav-0" className="mb-9 scroll-mt-[50px]">
       <DetailInformationTitle icon={placeIntroduce} title="공간 소개" />
-      <p className="break-keep font-system4 text-system4 text-GRAY_600">
-        {introduce}
-      </p>
+      {introduce?.map((content: string) => {
+        return content.split('\n').map((line: string) => {
+          return (
+            <p
+              key={line}
+              className="break-keep text-system4 font-system4 text-GRAY_600"
+            >
+              {line}
+            </p>
+          );
+        });
+      })}
     </section>
   );
 }

--- a/src/components/detail/placeDetailNav/PlaceLocation.tsx
+++ b/src/components/detail/placeDetailNav/PlaceLocation.tsx
@@ -20,6 +20,7 @@ function PlaceLocation({ place, location }: PlaceLocationProps) {
 
   const [address, setAddress] = useState<string>(location);
   const [isRoadName, setIsRoadName] = useState<boolean>(false);
+  const [addressHeight, setAddressHeight] = useState<number>(0);
   const { value } = useGetPlaceAddress({ placeId, isRoadName }, address);
   const copyLocation = async () => {
     await navigator.clipboard.writeText(location);
@@ -31,6 +32,8 @@ function PlaceLocation({ place, location }: PlaceLocationProps) {
 
   useEffect(() => {
     setAddress(value?.data);
+    const height = document.getElementById('address')?.clientHeight;
+    if (height) setAddressHeight(height);
   }, [value]);
 
   return (
@@ -38,7 +41,6 @@ function PlaceLocation({ place, location }: PlaceLocationProps) {
       <DetailInformationTitle icon={placeLocation} title="공간 위치" />
       <div className="border-color-GRAY_100 rounded-[10px] 	border-[1px]">
         <Link
-          className="h-[300px] bg-BLUE_100"
           href={{
             pathname: `/detail/${router.query.id}/location`,
             query: {
@@ -47,9 +49,12 @@ function PlaceLocation({ place, location }: PlaceLocationProps) {
             },
           }}
         >
-          <Map location={location} />
+          <Map addressHeight={addressHeight} location={location} />
         </Link>
-        <p className="mx-[14px] my-3 flex justify-start text-system5_medium font-system5_medium text-GRAY_800">
+        <p
+          id="address"
+          className="mx-[14px] my-3 flex justify-start text-system5_medium font-system5_medium text-GRAY_800"
+        >
           {address}
         </p>
         <div className="border-color-GRAY_100 mx-[3px] h-[1px] border-[1px]" />

--- a/src/components/detail/placeInfo.tsx
+++ b/src/components/detail/placeInfo.tsx
@@ -14,7 +14,7 @@ function PlaceInfo({ category, place, distance, hashtags }: PlaceInfoProps) {
   return (
     <>
       <section className="mb-2 mt-8 flex flex-row items-center justify-between">
-        <p className="font-system6_medium text-system6_medium text-GRAY_400">
+        <p className="text-system6_medium font-system6_medium text-GRAY_400">
           {category === '0' ? '무료 대여 공간' : '무료 회의룸'}
         </p>
         <article className="flex flex-row items-center justify-center">
@@ -22,7 +22,7 @@ function PlaceInfo({ category, place, distance, hashtags }: PlaceInfoProps) {
           <Image src={book} alt="book" className="cursor-pointer" />
         </article>
       </section>
-      <h1 className="mb-2 font-system2_bold text-system2_bold text-GRAY_800">
+      <h1 className="mb-2 text-system2_bold font-system2_bold text-GRAY_800">
         {place}
       </h1>
       <section className="mb-2 flex flex-row items-center">
@@ -31,7 +31,7 @@ function PlaceInfo({ category, place, distance, hashtags }: PlaceInfoProps) {
             return (
               <article key={index} className="flex flex-row">
                 <Image src={spot} alt="spot" className="mr-2.5" />
-                <p className="font-system5 text-system5 text-GRAY_600">
+                <p className="mr-2.5 text-system5 font-system5 text-GRAY_600">
                   {station} {value}
                 </p>
               </article>
@@ -43,7 +43,7 @@ function PlaceInfo({ category, place, distance, hashtags }: PlaceInfoProps) {
           return (
             <article
               key={index}
-              className="mr-1.5 rounded-3xl bg-BLUE_100 pb-1 pl-2  pr-2 pt-1 font-system6 text-system6 text-BLUE_700"
+              className="mr-1.5 rounded-3xl bg-BLUE_100 pb-1 pl-2  pr-2 pt-1 text-system6 font-system6 text-BLUE_700"
             >
               {tag}
             </article>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -35,20 +35,25 @@ body {
 
 /* react-slick css */
 
-.slick-slider .slick-dots button:before {
+.detail-slider {
+  margin-left: -1rem;
+  width: 100vw;
+}
+
+.detail-slider .slick-dots button:before {
   color: #c5cbd5;
 }
 
-.slick-slider .slick-dots li.slick-active button::before {
+.detail-slider .slick-dots li.slick-active button::before {
   color: #3687ff;
   opacity: 1;
 }
 
-.slick-slider .slick-dots {
+.detail-slider .slick-dots {
   bottom: -30px;
 }
 
-.slick-slider .slick-dots li {
+.detail-slider .slick-dots li {
   width: 10px;
   font-size: 4px;
 }


### PR DESCRIPTION
### 관련 이슈
- close #53
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부  -->

- [x] 공간 상세 뷰 slick className으로 스타일 지정
- [x] 시설 정보 없을때 (null ) "-"  표기
<img width="322" alt="스크린샷 2023-06-16 오후 12 06 04" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/1e5d1eb5-39f7-4f24-ac3e-4a21a7c45573">

- [x] 지도에서 location 로딩 전에 지도가 로드되어 빈 화면으로 뜨는 문제 해결 
<img width="309" alt="스크린샷 2023-06-16 오후 12 15 53" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/db91908b-90c6-4a52-ad85-c16b2073982e">


-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->

공간 상세 뷰 페이지에서 위에 사항들을 수정했습니다!

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

