### PR TITLE
지도뷰 공간리스트 마커 찍기 구현

### DIFF
--- a/src/components/nearby-place/Map.tsx
+++ b/src/components/nearby-place/Map.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  Dispatch,
-  SetStateAction,
-  useContext,
-} from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import Image from 'next/image';
 import centerBtn from '@/assets/icons/center_button.svg';
 import { usePlaceList } from '@/hooks/queries/usePlaceList';
@@ -23,12 +17,12 @@ interface PlacePosition {
 }
 
 interface MapProps {
-  setStationName: Dispatch<SetStateAction<string>>;
+  onChange: (station: string) => void;
   station: string;
 }
 
 function Map(props: MapProps) {
-  const { setStationName, station } = props;
+  const { onChange, station } = props;
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [cmap, setMap]: any = useState();
   const [cposition, setPosition] = useState();
@@ -98,7 +92,7 @@ function Map(props: MapProps) {
                 setPosition(
                   new window.kakao.maps.LatLng(result[0].y, result[0].x),
                 );
-                setStationName(result[0].place_name.split(' ')[0]);
+                onChange(result[0].place_name.split(' ')[0]);
               }
             };
 
@@ -114,7 +108,7 @@ function Map(props: MapProps) {
                 setPosition(
                   new window.kakao.maps.LatLng(result[0].y, result[0].x),
                 );
-                setStationName(result[0].place_name.split(' ')[0]);
+                onChange(result[0].place_name.split(' ')[0]);
               }
             };
             const options = {

--- a/src/components/nearby-place/Map.tsx
+++ b/src/components/nearby-place/Map.tsx
@@ -104,7 +104,7 @@ function Map(props: MapProps) {
 
             places.keywordSearch(stationQuery, callback);
             if (cmap) {
-              cmap.setCenter(cposition);
+              cmap.panTo(cposition);
             }
           } else {
             const places = new window.kakao.maps.services.Places();
@@ -225,7 +225,7 @@ function Map(props: MapProps) {
 
   const onCenter = () => {
     if (cmap) {
-      cmap.setCenter(cposition);
+      cmap.panTo(cposition);
     }
   };
 

--- a/src/components/nearby-place/Map.tsx
+++ b/src/components/nearby-place/Map.tsx
@@ -86,7 +86,7 @@ function Map(props: MapProps) {
           const mapContainer = document.getElementById('map');
           const mapOption = {
             center: locPosition, // 지도의 중심좌표
-            level: 3, // 지도의 확대 레벨
+            level: 6, // 지도의 확대 레벨
           };
           const map = await new window.kakao.maps.Map(mapContainer, mapOption);
           setMap(map);

--- a/src/pages/nearby-place/[[...station]].tsx
+++ b/src/pages/nearby-place/[[...station]].tsx
@@ -19,7 +19,10 @@ function NearbyPlace() {
       <Layout title={station || stationName} right={profile}>
         <Navigation />
         <div className="flex">
-          <Map setStationName={setStationName}></Map>
+          <Map
+            setStationName={setStationName}
+            station={station.replace('역', '') || stationName}
+          ></Map>
           <BottomSheet stationName={station || stationName} />
         </div>
       </Layout>

--- a/src/pages/nearby-place/[[...station]].tsx
+++ b/src/pages/nearby-place/[[...station]].tsx
@@ -22,7 +22,7 @@ function NearbyPlace() {
           <Map
             setStationName={setStationName}
             station={station.replace('역', '') || stationName}
-          ></Map>
+          />
           <BottomSheet stationName={station || stationName} />
         </div>
       </Layout>

--- a/src/pages/nearby-place/[[...station]].tsx
+++ b/src/pages/nearby-place/[[...station]].tsx
@@ -14,13 +14,17 @@ function NearbyPlace() {
   const station = query ? query[0] : '';
   const [stationName, setStationName] = useState('');
 
+  const onChange = (station: string) => {
+    setStationName(station);
+  };
+
   return (
     <NavigationContextProvider>
       <Layout title={station || stationName} right={profile}>
         <Navigation />
         <div className="flex">
           <Map
-            setStationName={setStationName}
+            onChange={onChange}
             station={station.replace('역', '') || stationName}
           />
           <BottomSheet stationName={station || stationName} />


### PR DESCRIPTION
### 관련 이슈
- close #57 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->
![마커찍기](https://github.com/WOK-AT/WOKAT_CLIENT/assets/87795291/17660d75-ab24-46bd-b520-2e47a4070742)

- [x] 지도뷰에 공간리스트 데이터로 받아온 장소들의 마커를 찍습니다
-----------------

### Message
- 서영언니가 말해줬던 참조 해제 코드를 넣어줬습니다!
- 원래 지도 확대레벨이 3이었는데, 공간리스트 보니까 역에서 꽤 멀리 있는 장소들도 표시가 되길래.. 확대 레벨을 좀 더 높여서 넓은 범위가 보일 수 있게 변경했습니다.
- 리스트뷰에서 받아온 리스트 정보를 그대로 가지고 지도 뷰로 옮겨가면, 지도뷰 바텀시트에서는 이미 캐싱된 리스트 데이터를 가져올테니 빠르겠지? 라고 생각했는데... 리액트 쿼리의 캐시 메모리는 같은 화면 내에서만 유지돼서 다른 화면으로 가면 또 다시 refetch를 해와야 되더라구요 ㅎㅎ.. 아쉽네요 . . . . 
- 리스트 정보가 불러와지기 전에(마커 찍히기 전에) 지도 로드도 하지 말아야 좋을까요?! 어떻게 생각하시나욥🤔
- 지도 확대 축소 시 깜빡거리면서 예전에 찍혔던 마커가 보인다거나 하는 현상이 있어서 고치려고 알아봤는데, 카카오맵 api의 고질병이라고 하네요...

<!-- 남기고 싶은 말 or 팀원 언급 -->

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

