### PR TITLE
[Fix] 내주변 장소 찾기 지도 겹치는 오류 수정

### DIFF
--- a/src/components/nearby-place/Map.tsx
+++ b/src/components/nearby-place/Map.tsx
@@ -23,7 +23,7 @@ interface MapProps {
 
 function Map(props: MapProps) {
   const { onChange, stationName } = props;
-  const [cmap, setMap]: any = useState();
+  const [cmap, setCmap]: any = useState(null);
   const [cposition, setPosition] = useState();
   const [markers, setMarkers]: any = useState([]);
   const [overlays, setOverlays]: any = useState([]);
@@ -75,7 +75,8 @@ function Map(props: MapProps) {
               mapContainer,
               mapOption,
             );
-            setMap(map);
+            await setCmap(map);
+            setPosition(locPosition);
 
             //근처 지하철역 찾기
             if (stationQuery !== undefined && stationQuery[0] !== '') {
@@ -89,21 +90,22 @@ function Map(props: MapProps) {
                 }
               };
 
-              places.keywordSearch(stationQuery, callback);
+              await places.keywordSearch(stationQuery, callback);
               if (cmap) {
-                cmap.panTo(cposition);
+                await cmap.panTo(cposition);
               }
             } else {
               const places = new window.kakao.maps.services.Places();
 
               const callback = (result: any, status: any) => {
                 if (status === window.kakao.maps.services.Status.OK) {
+                  console.log();
                   setPosition(
                     new window.kakao.maps.LatLng(result[0].y, result[0].x),
                   );
                   onChange(result[0].place_name.split(' ')[0]);
                 } else {
-                  setPosition(locPosition);
+                  // setPosition(locPosition);
                   onChange('역없음');
                 }
               };
@@ -116,7 +118,7 @@ function Map(props: MapProps) {
 
               await places.keywordSearch('지하철역', callback, options);
               if (cmap) {
-                cmap.setCenter(cposition);
+                await cmap.panTo(cposition);
               }
             }
           });
@@ -144,9 +146,8 @@ function Map(props: MapProps) {
     }
 
     if (!cmap) return;
-
-    if (cmap !== undefined) {
-      cmap.panTo(cposition);
+    if (cmap) {
+      cmap?.panTo(cposition);
 
       //위치마다 마커를 생성합니다
       for (let i = 0; i < placeList.length; i++) {

--- a/src/components/nearby-place/Map.tsx
+++ b/src/components/nearby-place/Map.tsx
@@ -23,9 +23,10 @@ interface MapProps {
 
 function Map(props: MapProps) {
   const { onChange, stationName } = props;
-  const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [cmap, setMap]: any = useState();
   const [cposition, setPosition] = useState();
+  const [markers, setMarkers]: any = useState([]);
+  const [overlays, setOverlays]: any = useState([]);
 
   const station =
     stationName.charAt(stationName.length - 1) === '역'
@@ -33,7 +34,7 @@ function Map(props: MapProps) {
       : stationName;
 
   const { navType } = useContext(NavigationContext);
-  const { data: placeList, isLoading } = usePlaceList({ station, navType });
+  const { data: placeList } = usePlaceList({ station, navType });
   const router = useRouter();
   const stationQuery = router.query.station as string[];
   let selectedMarker: any = null;
@@ -50,98 +51,102 @@ function Map(props: MapProps) {
     return customOverlayContent;
   };
 
-  //지도 로드하기
+  //주변 지하철 역 찾고 지도 로드하기
   useEffect(() => {
     const mapScript = document.createElement('script');
-    mapScript.async = true;
+    mapScript.async = false;
     mapScript.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAOMAP_KEY}&autoload=false&libraries=services`;
-
-    const handleScriptLoad = () => {
-      setMapLoaded(true);
-    };
-
-    if (location) {
-      mapScript.addEventListener('load', handleScriptLoad);
-    }
     document.head.appendChild(mapScript);
 
+    const handleScriptLoad = () => {
+      window.kakao.maps.load(async () => {
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(async (position) => {
+            const lat = position.coords.latitude; // 위도
+            const lon = position.coords.longitude; // 경도
+            const locPosition = new window.kakao.maps.LatLng(lat, lon);
+
+            const mapContainer = document.getElementById('map');
+            const mapOption = {
+              center: locPosition, // 지도의 중심좌표
+              level: 6, // 지도의 확대 레벨
+            };
+            const map = await new window.kakao.maps.Map(
+              mapContainer,
+              mapOption,
+            );
+            setMap(map);
+
+            //근처 지하철역 찾기
+            if (stationQuery !== undefined && stationQuery[0] !== '') {
+              const places = new window.kakao.maps.services.Places();
+              const callback = (result: any, status: any) => {
+                if (status === window.kakao.maps.services.Status.OK) {
+                  setPosition(
+                    new window.kakao.maps.LatLng(result[0].y, result[0].x),
+                  );
+                  onChange(result[0].place_name.split(' ')[0]);
+                }
+              };
+
+              places.keywordSearch(stationQuery, callback);
+              if (cmap) {
+                cmap.panTo(cposition);
+              }
+            } else {
+              const places = new window.kakao.maps.services.Places();
+
+              const callback = (result: any, status: any) => {
+                if (status === window.kakao.maps.services.Status.OK) {
+                  setPosition(
+                    new window.kakao.maps.LatLng(result[0].y, result[0].x),
+                  );
+                  onChange(result[0].place_name.split(' ')[0]);
+                } else {
+                  setPosition(locPosition);
+                  onChange('역없음');
+                }
+              };
+              const options = {
+                location: locPosition,
+                radius: 10000,
+                sort: window.kakao.maps.services.SortBy.DISTANCE,
+                size: 1,
+              };
+
+              await places.keywordSearch('지하철역', callback, options);
+              if (cmap) {
+                cmap.setCenter(cposition);
+              }
+            }
+          });
+        } else {
+          alert('주변 장소 찾기에 실패했어요');
+        }
+      });
+    };
+    mapScript.addEventListener('load', handleScriptLoad);
     return () => {
       if (location) mapScript.removeEventListener('load', handleScriptLoad);
       document.head.removeChild(mapScript);
     };
   }, []);
 
-  //지도 로드 후 근처 지하철역 찾기
-  useEffect(() => {
-    if (!mapLoaded) return;
-
-    window.kakao.maps.load(async () => {
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(async (position) => {
-          const lat = position.coords.latitude; // 위도
-          const lon = position.coords.longitude; // 경도
-          const locPosition = new window.kakao.maps.LatLng(lat, lon);
-
-          const mapContainer = document.getElementById('map');
-          const mapOption = {
-            center: locPosition, // 지도의 중심좌표
-            level: 6, // 지도의 확대 레벨
-          };
-          const map = await new window.kakao.maps.Map(mapContainer, mapOption);
-          setMap(map);
-
-          if (stationQuery !== undefined && stationQuery[0] !== '') {
-            const places = new window.kakao.maps.services.Places();
-            const callback = (result: any, status: any) => {
-              if (status === window.kakao.maps.services.Status.OK) {
-                setPosition(
-                  new window.kakao.maps.LatLng(result[0].y, result[0].x),
-                );
-                onChange(result[0].place_name.split(' ')[0]);
-              }
-            };
-
-            places.keywordSearch(stationQuery, callback);
-            if (cmap) {
-              cmap.panTo(cposition);
-            }
-          } else {
-            const places = new window.kakao.maps.services.Places();
-
-            const callback = (result: any, status: any) => {
-              if (status === window.kakao.maps.services.Status.OK) {
-                setPosition(
-                  new window.kakao.maps.LatLng(result[0].y, result[0].x),
-                );
-                onChange(result[0].place_name.split(' ')[0]);
-              } else {
-                setPosition(locPosition);
-                onChange('역없음');
-              }
-            };
-            const options = {
-              location: locPosition,
-              radius: 10000,
-              sort: window.kakao.maps.services.SortBy.DISTANCE,
-              size: 1,
-            };
-
-            await places.keywordSearch('지하철역', callback, options);
-            if (cmap) {
-              cmap.setCenter(cposition);
-            }
-          }
-        });
-      } else {
-        alert('위치 정보를 받아오는데 실패했습니다');
-      }
-    });
-  }, [mapLoaded, navType]);
-
   //근처 지하철역으로 중심좌표 이동 및 마커 표시
   useEffect(() => {
-    if (cmap) {
-      cmap.setCenter(cposition);
+    //저번에 찍혔던 마커와 오버레이는 모두 삭제하고 새로운 마커와 오버레이를 찍습니다
+    for (let i = 0; i < markers.length; i++) {
+      markers[i].setMap(null);
+    }
+
+    for (let i = 0; i < overlays.length; i++) {
+      overlays[i].setMap(null);
+    }
+
+    if (!cmap) return;
+
+    if (cmap !== undefined) {
+      cmap.panTo(cposition);
 
       //위치마다 마커를 생성합니다
       for (let i = 0; i < placeList.length; i++) {
@@ -183,6 +188,8 @@ function Map(props: MapProps) {
                 image: normalMarkerImage,
               });
 
+              markers.push(marker);
+
               const customOverlayContent = getOverlayContent(
                 placeList[i].place,
               );
@@ -193,6 +200,8 @@ function Map(props: MapProps) {
               });
 
               customOverlay.setMap(cmap);
+
+              overlays.push(customOverlay);
 
               window.kakao.maps.event.addListener(marker, 'click', () => {
                 // 클릭된 마커가 없고, click 마커가 클릭된 마커가 아니면
@@ -233,7 +242,7 @@ function Map(props: MapProps) {
         );
       }
     }
-  }, [cposition, isLoading]);
+  }, [cposition, placeList]);
 
   const onCenter = () => {
     if (cmap) {


### PR DESCRIPTION
### 관련 이슈
- close #90 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->
![녀녀](https://github.com/WOK-AT/WOKAT_CLIENT/assets/87795291/2e2f4a2c-c8c0-453d-9972-6285ef6b9857)

- [x] 주변 장소 찾기 지도 겹침 오류 수정
- [x] 네브바 옮길 때 setCenter가 아니라 panto로 변경(부드럽게 가운데 좌표로 이동하게)
-----------------

### Message
1. 지도가 여러번 렌더링 된다는 지적을 받아서 그 부분을 수정했습니다.
- 현재 지도는 빈배열 useEffect에서 처음 주변 장소 찾기에 들어왔을 때에만 생성됩니다.

<br />
<br />

2. 기존에는 네비게이션이 바뀔 때마다 새로 map 생성+ 마커 생성이었는데, (그래서 마커를 삭제해줄 필요가 없었습니다. 애초에 새로운 map이 생성됐기 때문에!) => 내주변 장소찾기로 들어오고 처음에만 map을 생성해주는 방식으로 변경했습니다. 네비게이션바가 바뀌어도 같은 map 객체를 사용합니다.
- placeList가 바뀔때마다(네비게이션이 바뀔 때마다) `기존에 생성돼있던 마커와 오버레이 삭제 + 새로운 마커와 오버레이 올리기` 의 방식으로 구현을 변경했습니다.
- 덕분에 네비게이션이 바뀔때 지도가 깜빡이는거(새로 렌더링,생성되는거 없이) 없이 바텀시트만 바뀌고 마커만 새로 찍히는 식으로 돼서 조금 더 자연스러워 보이는 듯 합니다

<br />
<br />

3. `useEffect`도 두개로 줄었습니다. 각 `useEffect`의 역할은 다음과 같습니다.
- `빈배열 useEffect` => map생성 / 주변 지하철역 찾고 `cposition` 변수에 근처 지하철역 정보 저장
- `[cposition,placeList] useEffect` => 주변 지하철역으로 지도 중심좌표 이동 / 기존 마커, 커스텀오버레이(장소명) 삭제 / 새로운 마커+커스텀오버레이 찍기

<!-- 남기고 싶은 말 or 팀원 언급 -->

-----------
### Need Review
하나의 useEffect 안에서 많은 일을 하고 있어서 각 작업마다 함수로 구분을 해주는게 좋을까 싶은데.., 두 분은 어떻게 생각하시는지 궁금합니다!!!
<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

