### PR TITLE
Feat/#93 QA 및 기타 수정

### DIFF
--- a/src/components/WokatSEO.tsx
+++ b/src/components/WokatSEO.tsx
@@ -20,6 +20,7 @@ function WokatSEO(props: WokatSEOProps) {
 
       <meta property="og:title" content="WOKAT" />
       <meta property="og:description" content="일과 함께 워캣으로 떠나요!" />
+      <meta property="og:image" content="/assets/icons/logo.svg" />
     </Head>
   );
 }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import arrow_back from '@/assets/icons/arrow_back.svg';
 import logo from '@/assets/icons/logo.svg';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 interface HeaderProps {
   title?: string;
@@ -14,8 +15,8 @@ function Header(props: HeaderProps) {
   const showBackButton = router.pathname !== '/';
 
   return (
-    <header className="flex items-center justify-between px-4 cursor-pointer h-14">
-      <button id="back" aria-label="Header Left" className="relative w-6 h-6">
+    <header className="flex h-14 cursor-pointer items-center justify-between px-4">
+      <button id="back" aria-label="Header Left" className="relative h-6 w-6">
         {showBackButton && (
           <Image
             src={arrow_back}
@@ -31,15 +32,15 @@ function Header(props: HeaderProps) {
           {title}
         </h1>
       ) : (
-        <div className="relative h-[13px] w-[105px]">
+        <Link href="/" className="relative h-[13px] w-[105px]">
           <Image src={logo} alt="wokat_logo" fill />
-        </div>
+        </Link>
       )}
 
       <button
         id="profile"
         aria-label="Header Right"
-        className="relative w-6 h-6"
+        className="relative h-6 w-6"
       >
         {right && <Image src={right} alt="right_icon" fill />}
       </button>

--- a/src/components/list/PlaceItem.tsx
+++ b/src/components/list/PlaceItem.tsx
@@ -44,7 +44,7 @@ function PlaceItem(props: PlaceItemProps) {
               height={20}
             />
             <p className=" text-system5 font-system5 text-GRAY_600 max-[360px]:text-system6">
-              {Object.values(distance).join('')}
+              {distance}
             </p>
           </div>
           <div className="flex">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -33,6 +33,13 @@ body {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+/* Safari ver 15 이상에서 로딩 중 이미지 회색 테두리 표시 제거 */
+@supports (font: -apple-system-body) and (-webkit-appearance: none) {
+  img[loading='lazy'] {
+    clip-path: inset(0.6px);
+  }
+}
+
 /* react-slick css */
 
 .detail-slider {


### PR DESCRIPTION
### 관련 이슈
- close #93 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->
### Safari에서 이미지 로딩 시 회색 테두리가 생기는 이슈를 해결했습니다.
![image](https://github.com/WOK-AT/WOKAT_CLIENT/assets/66051416/bc093eca-82ef-4df2-b7d6-0aa072959541)

```css
@supports (font: -apple-system-body) and (-webkit-appearance: none) {
  img[loading='lazy'] {
    clip-path: inset(0.6px);
  }
}
```
- [x] 헤더의 WOKAT 로고를 클릭하면 메인으로 돌아가도록 `Link href="/"`를 추가했습니다.
- [ ] og:image meta태그를 추가해서 카카오톡으로 워캣 웹사이트를 공유했을 때 썸네일이 뜨게 하기 위해 추가했어요.
(참고사진)
![image](https://github.com/WOK-AT/WOKAT_CLIENT/assets/66051416/8fb186bd-f1ff-4fd0-a26c-489b85fa5165)
첫번째 사진처럼 썸네일이 떠야 해요
우선 assets에 있는 logo.svg로 설정해두었는데, 적용이 제대로 안 될 가능성도 있어서 배포 후에 다시 체크해보겠습니다!


![image](https://github.com/WOK-AT/WOKAT_CLIENT/assets/66051416/9d05d83b-b0f1-4a87-b114-80f00a6ff8e5)
- [x] 서버 다현님이 수정해주신 도보거리 반영해서 distance를 배열로 뿌리던 코드를 string으로 출력되게 수정했습니다. 사실 기존에 distance의 type이 object가 아니라 string으로 되어있어서 `Object.values(distance).join('')` <- 요 코드가 의미가 없었네요 😅
-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

