### PR TITLE
Feat/#99 3차 QA 및 사용성 개선 + 추가 QA 반영

### DIFF
--- a/src/components/list/PlaceItem.tsx
+++ b/src/components/list/PlaceItem.tsx
@@ -3,7 +3,7 @@ import list_profile from '@/assets/icons/list_profile.svg';
 import list_location from '@/assets/icons/list_location.svg';
 import fallbackImage from '@/assets/images/background.webp';
 import { Place } from '@/services/list/types';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 const transparent =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkqAcAAIUAgUW0RjgAAAAASUVORK5CYII=';

--- a/src/components/list/PlaceItem.tsx
+++ b/src/components/list/PlaceItem.tsx
@@ -3,6 +3,7 @@ import list_profile from '@/assets/icons/list_profile.svg';
 import list_location from '@/assets/icons/list_location.svg';
 import fallbackImage from '@/assets/images/background.webp';
 import { Place } from '@/services/list/types';
+import { useEffect, useState } from 'react';
 
 const transparent =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkqAcAAIUAgUW0RjgAAAAASUVORK5CYII=';
@@ -15,19 +16,26 @@ function PlaceItem(props: PlaceItemProps) {
   const {
     data: { place, count, hashtags = [], distance, imageURL },
   } = props;
+  const [error, setError] = useState(false);
+
+  const onError = () => {
+    setError(true);
+  };
 
   return (
     <>
       <div className="relative">
         <div className="relative flex h-[120px] w-[100px] items-center justify-center max-[360px]:h-[100px] max-[360px]:w-[80px]">
           <Image
-            src={imageURL || fallbackImage}
+            src={error ? fallbackImage : imageURL ?? fallbackImage}
             alt={place}
-            className="overflow-hidden rounded"
+            className="overflow-hidden rounded bg-cover"
+            style={{ objectFit: 'cover' }}
             placeholder="blur"
             blurDataURL={`data:image/gif;base64,${transparent}`}
             fill
             sizes="(max-width: 768px) 100vw"
+            onError={onError}
           />
         </div>
       </div>

--- a/src/pages/list/index.tsx
+++ b/src/pages/list/index.tsx
@@ -4,9 +4,7 @@ import Navigation from '@/components/common/Navigation';
 import FAB from '@/components/list/FAB';
 import { Suspense } from 'react';
 import Skeleton from '@/components/list/Skeleton';
-import dynamic from 'next/dynamic';
-
-const PlaceList = dynamic(() => import('@/components/list/PlaceList'));
+import PlaceList from '@/components/list/PlaceList';
 
 function List() {
   const router = useRouter();


### PR DESCRIPTION
### 관련 이슈
- close #99 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->

![image](https://github.com/WOK-AT/WOKAT_CLIENT/assets/66051416/951039d4-9caf-4f4e-914e-db4d951336ab)

- [x] 리스트 뷰 이미지 비율 수정
- [x] 이미지 경로 제대로 못 받아올 때 엑박 뜨는 이슈 해결
- [x] 지도 플로팅 액션 버튼 클릭 시 라우팅 안되는 이슈 해결
-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->
### 1️⃣ 리스트 뷰 이미지 비율 수정

inline-style에 `object-fit` 속성 추가했습니다. Tailwind로는 적용이 안되네요? ㅎㅎ

### 2️⃣ 이미지 경로 제대로 못 받아올 때 엑박 뜨는 이슈 해결

지금은 삭제했지만 저번 PR에서 삭제한 `ImageFallback` 컴포넌트에 적용했던 `onError`를 다시 살렸습니다.

imageURL이 없는 경우를 제외하고 Error가 발생하면 onError에서 감지해서 fallbackImage를 띄우도록 했어요.

### 3️⃣ 지도 플로팅 액션 버튼 클릭 시 라우팅 안되는 이슈 해결

React.Suspense 쓸 때 일반적으로 **dynamic import**를 함께 쓴다고 알고 있었는데 이것 때문에 Link 태그가 제대로 작동하지 않았어요. 

dynamic을 제거함으로써 발생하는 성능 이슈를 발견한다면 추후 수정하겠습니다!

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

