### PR TITLE
[Fix] 공간 상세 뷰 스크롤

### DIFF
--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -38,14 +38,18 @@ function DetailNavigator() {
       return document.documentElement.scrollTop || document.body.scrollTop;
     };
 
+    const getScrollHeigth = () => {
+      return (
+        document.body.scrollHeight || document.documentElement.scrollHeight
+      );
+    };
+
     const handleScroll = () => {
       const placeLocationComponent = document.getElementById('nav-3');
 
       if (
         placeLocationComponent &&
-        getScrollTop() >
-          placeLocationComponent?.offsetTop -
-            placeLocationComponent?.offsetHeight
+        getScrollTop() + document.body.offsetHeight >= getScrollHeigth()
       ) {
         activeNavigator(3);
       } else {

--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -38,7 +38,7 @@ function DetailNavigator() {
       return document.documentElement.scrollTop || document.body.scrollTop;
     };
 
-    const getScrollHeigth = () => {
+    const getScrollHeight = () => {
       return (
         document.body.scrollHeight || document.documentElement.scrollHeight
       );
@@ -55,7 +55,7 @@ function DetailNavigator() {
 
       if (
         placeLocationComponent &&
-        getScrollTop() + getScrollOffsetHeight() >= getScrollHeigth()
+        getScrollTop() + getScrollOffsetHeight() >= getScrollHeight()
       ) {
         activeNavigator(3);
       } else {

--- a/src/components/detail/DetailNavigator.tsx
+++ b/src/components/detail/DetailNavigator.tsx
@@ -44,12 +44,18 @@ function DetailNavigator() {
       );
     };
 
+    const getScrollOffsetHeight = () => {
+      return (
+        document.body.offsetHeight || document.documentElement.offsetHeight
+      );
+    };
+
     const handleScroll = () => {
       const placeLocationComponent = document.getElementById('nav-3');
 
       if (
         placeLocationComponent &&
-        getScrollTop() + document.body.offsetHeight >= getScrollHeigth()
+        getScrollTop() + getScrollOffsetHeight() >= getScrollHeigth()
       ) {
         activeNavigator(3);
       } else {


### PR DESCRIPTION
### 관련 이슈
- close #114 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->
- [x] 공간 상세 뷰에서 공간 위치 컴포넌트에 도달했을때 네비게이션 탭이 작동하지 않는 이슈
-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->

![image](https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/4cabd968-6fda-446a-b75a-1bad9b562f58)
이번에 네비게이션 탭으로 스크롤 이벤트를 구현하면서 이 그림을 참고하였습니다!

원래는 하단에서 특정 픽셀내로 스크롤이 들어오면 공간 위치 탭이 활성화 되도록 했는데, 화면 크기별로 픽셀이 달라져야하는 문제가 생겨서 하단에 닿으면 활성화 되는 방식으로 바꿨습니다.

현재 스크롤 위치에 (scrolltop)에다가 현재 화면의 크기 (offsetHeight)을 더해서 총 스크롤의 너비(scrollHeight)보다 같거나 크면 공간 위치 탭이 활성화 됩니다!

-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

