### PR TITLE
[Chore] 피드백 메시지 아이콘 object tag로 변경

### DIFF
--- a/src/components/common/FeedbackButton.tsx
+++ b/src/components/common/FeedbackButton.tsx
@@ -18,11 +18,10 @@ function FeedbackButton() {
         <Image src={feedback} alt="feedback_icon" fill />
       </button>
       {router.pathname === '/' && (
-        <Image
-          className="absolute right-[6px] top-[34px]"
-          src={feedbackInfoText}
-          alt="feedbackInfoText_icon"
-          layout="fixed"
+        <object
+          type="image/svg+xml"
+          className="absolute right-[6px] top-[37px]"
+          data={feedbackInfoText.src}
         />
       )}
     </section>


### PR DESCRIPTION
### 관련 이슈
- close #131 
<!-- ✏️ 이슈 넘버를 달아서 이슈를 닫아주세요. -->

### 구현 사항
<!-- 필요하다면 사진 첨부 -->
- [x] 피드백 메시지 아이콘 object tag로 변경
<img width="424" alt="image" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/f336016b-3feb-4e8d-a4a1-b8f095360afe">

-----------------

### Message

<!-- 남기고 싶은 말 or 팀원 언급 -->

사파리에서 svg+Image tag 를 사용했을때 깨지는 문제가 발생했습니다.
이를 수정하기 위해 webp 파일 형식으로 바꿔보았는데, webp로 했을때도 이미지가 깨지고, 피그마 디자인보다 색감도 어두워진 것 같아 
svg 파일을 사용하고 `object` 태그를 사용하는 것으로 변경하였습니다!

**[webp]**
<img width="267" alt="image" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/c6c7cdac-9321-4fde-a5dd-dc0c4a7200af">
**[svg]**
<img width="293" alt="image" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/2a0c1ea4-5ece-44e8-bf92-df7768262081">
**[피그마]**
<img width="693" alt="image" src="https://github.com/WOK-AT/WOKAT_CLIENT/assets/62867581/559ce7d2-34cc-4dfd-a02b-7207039ddef2">


-----------
### Need Review

<!-- 리뷰어가 주목해줬으면 하는 코드 or 리뷰가 필요한 부분 -->

------------
### Reference

<!-- 참고한 링크 첨부 -->

-------------

